### PR TITLE
DOCS-2556 Use date-based "latest" selection in select_api_versions.py

### DIFF
--- a/scripts/select_api_versions.py
+++ b/scripts/select_api_versions.py
@@ -38,14 +38,22 @@ def extract_major_version(version_string: str) -> str:
         v24.10.2.4 -> "24.10"
         v25.04.0 -> "25.04"
         v25.10.2 -> "25.10"
-        v26.04.0 -> "26.04"
+        v25.10-BETA.1 -> "25.10"
+        v26.0.0 -> "26.0"
+        v26.0.0-BETA.1 -> "26.0"
+        v26.1.0 -> "26.1"
 
     Returns major version without 'v' prefix.
     """
     # Remove 'v' prefix if present
     version = version_string.lstrip('v')
 
-    # Split by dots and take first two parts (Year.Month)
+    # Strip hyphenated pre-release suffix (BETA.1, RC.1) before splitting, so
+    # pre-release directories don't get bucketed under a bogus "X.Y-BETA" major.
+    if '-' in version:
+        version = version.split('-', 1)[0]
+
+    # Split by dots and take first two parts (Year.Month or semver Major.Minor)
     parts = version.split('.')
     if len(parts) >= 2:
         return f"{parts[0]}.{parts[1]}"
@@ -111,8 +119,8 @@ def match_release_to_directory(release_version: str, available_versions: List[st
     if not matches:
         return None
 
-    # Sort by semantic version
-    sorted_matches = sorted(matches, key=lambda v: [int(x) if x.isdigit() else x for x in v.lstrip('v').split('.')], reverse=True)
+    # Sort highest-first using the pre-release-aware comparator (see _sort_versions_desc).
+    sorted_matches = _sort_versions_desc(matches)
 
     # For exact patch-level matches, prefer the exact version
     exact_match = f"v{release_version}"
@@ -160,6 +168,43 @@ def _parse_release_date(rd):
         return datetime.date.fromisoformat(rd)
     except (ValueError, TypeError):
         return None
+
+
+def _sort_versions_desc(versions: List[str]) -> List[str]:
+    """Sort version directory names highest-first, tolerating pre-release suffixes.
+
+    Each dotted component is split into (leading-int, is-stable, trailing-str)
+    so mixed parts compare cleanly without TypeErrors AND pre-release suffixes
+    sort *below* the corresponding stable version (semver convention):
+        v25.10.3.1     -> [(25,True,""), (10,True,""), (3,True,""), (1,True,"")]
+        v25.10-BETA.1  -> [(25,True,""), (10,False,"-BETA"), (1,True,"")]
+    25.10.3.1 sorts higher than 25.10-BETA.1 because (10,True,"") > (10,False,"-BETA").
+    """
+    def key(v):
+        out = []
+        for part in v.lstrip('v').split('.'):
+            m = re.match(r'(\d+)(.*)$', part)
+            if m:
+                n = int(m.group(1))
+                suffix = m.group(2)
+                # `suffix == ''` is True for stable, False for pre-release; True
+                # sorts greater than False, so stable beats pre-release.
+                out.append((n, suffix == '', suffix))
+            else:
+                out.append((0, False, part))
+        return out
+    return sorted(versions, key=key, reverse=True)
+
+
+def _dir_major_for_lifecycle(lifecycle: str) -> str:
+    """Map a yaml lifecycle to the directory-major form `extract_major_version` returns.
+
+    YY.MM lifecycles (e.g., "25.10") match their own form. Integer lifecycles
+    (e.g., "26") map to `<lifecycle>.0` — the API directories use semver (26.0.0,
+    26.1.0, 26.0.1), so `extract_major_version("v26.0.0")` returns "26.0".
+    This mirrors the existing archived-majors bridge.
+    """
+    return lifecycle if '.' in lifecycle else f"{lifecycle}.0"
 
 
 def select_versions(release_data: Dict, available_versions: List[str]) -> Dict[str, str]:
@@ -248,15 +293,36 @@ def select_versions(release_data: Dict, available_versions: List[str]) -> Dict[s
         if not candidate:
             continue
 
-        parsed = parse_release_version(candidate.get('name', ''))
-        if not parsed:
+        lifecycle = major_version_group.get('lifecycle', '')
+        if not lifecycle:
             continue
+        dir_major = _dir_major_for_lifecycle(lifecycle)
 
-        major, full_version = parsed
-        matched_dir = match_release_to_directory(full_version, available_versions)
+        # First try an exact release-name → directory match (works for
+        # YY.MM patches like 25.10.3.1 where the yaml release name and the
+        # directory name align).
+        matched_dir = None
+        parsed = parse_release_version(candidate.get('name', ''))
+        if parsed:
+            _, full_version = parsed
+            matched_dir = match_release_to_directory(full_version, available_versions)
+
+        # No exact match — bridge from yaml lifecycle to directory major and
+        # pick the highest semver among directories belonging to this lifecycle.
+        # Covers integer-lifecycle cases (yaml "26-BETA.1" doesn't match
+        # directory "v26.0.0-BETA.1" literally, but both belong to dir_major "26.0").
+        if not matched_dir:
+            bridged = [v for v in available_versions if extract_major_version(v) == dir_major]
+            if bridged:
+                matched_dir = _sort_versions_desc(bridged)[0]
+
         if matched_dir:
-            selected[f"v{major}"] = matched_dir
-            matched_majors.add(major)
+            selected[f"v{dir_major}"] = matched_dir
+            matched_majors.add(dir_major)
+            if '.' not in lifecycle:
+                # Mirror the archived-majors bridge so the fallback loop below
+                # doesn't re-emit the lifecycle under its branding-only key.
+                matched_majors.add(lifecycle)
 
     # Handle versions not in release data (fallback to semver)
     available_by_major = {}
@@ -271,8 +337,7 @@ def select_versions(release_data: Dict, available_versions: List[str]) -> Dict[s
 
     # For each unmatched major, select highest semver
     for major, versions in available_by_major.items():
-        sorted_versions = sorted(versions, key=lambda v: [int(x) if x.isdigit() else x for x in v.lstrip('v').split('.')], reverse=True)
-        selected[f"v{major}"] = sorted_versions[0]
+        selected[f"v{major}"] = _sort_versions_desc(versions)[0]
 
     return selected
 

--- a/scripts/select_api_versions.py
+++ b/scripts/select_api_versions.py
@@ -2,8 +2,11 @@
 """
 Intelligent API version selection based on TrueNAS release data.
 
-Prioritizes versions marked as latest=true in scale-releases.yaml over
-higher semantic versions that are unreleased development builds.
+Selects, per major version, the entry with the most recent shipped
+`releaseDate` (parseable date <= today) from scale-releases.yaml. This
+prevents the script from publishing API docs for unreleased development
+builds whose directories happen to outrank the actual shipped release in
+semver order.
 
 Usage:
     python3 select_api_versions.py <scale-releases.yaml> <version1> <version2> ...
@@ -16,6 +19,7 @@ Output:
 import sys
 import json
 import re
+import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -143,14 +147,36 @@ def load_release_data(yaml_path: str) -> Optional[Dict]:
         return None
 
 
+def _parse_release_date(rd):
+    """Return a datetime.date for ISO yyyy-mm-dd strings, else None.
+
+    Sentinel strings used in scale-releases.yaml ("TBD" for unscheduled future
+    releases, "Ongoing" for continuous nightly tracks) and empty/missing dates
+    all return None — they do not represent a shipped point-in-time release.
+    """
+    if not rd or rd in ('TBD', 'Ongoing'):
+        return None
+    try:
+        return datetime.date.fromisoformat(rd)
+    except (ValueError, TypeError):
+        return None
+
+
 def select_versions(release_data: Dict, available_versions: List[str]) -> Dict[str, str]:
     """
     Select one version per major version based on release data.
 
-    Priority:
-    1. Versions with latest=true in scale-releases.yaml
-    2. Among latest versions, prioritize: Maintenance > Early > Experimental
-    3. Fallback to highest semver for majors not in release data
+    Strategy:
+    1. For each non-archived major, pick the release entry with the most recent
+       `releaseDate` that's a parseable date <= today (i.e., the latest shipped
+       release). Type priority breaks ties when multiple entries share a date
+       (rare): Maintenance/Stable > Early Release > Experimental.
+    2. If a major has no dated/shipped entries (e.g., nightlies-only majors in
+       the `preview` state where every entry has `releaseDate: "Ongoing"`), fall
+       back to the highest-priority "Ongoing" entry so the major is still
+       represented in the API docs.
+    3. For majors not present in release data at all, fall back to the highest
+       semver directory in `available_versions`.
 
     Majors marked `state: "archived"` are excluded entirely — they do not
     appear in the returned mapping and therefore not in api_versions.yaml.
@@ -177,11 +203,15 @@ def select_versions(release_data: Dict, available_versions: List[str]) -> Dict[s
 
     selected = {}
     matched_majors = set()
+    today = datetime.date.today()
 
-    # Priority order for release types
+    # Priority order for release types — matches the `type:` strings used in
+    # scale-releases.yaml. Used as a tiebreaker when entries share a date, and
+    # for picking among multiple "Ongoing" entries in the nightlies fallback.
     type_priority = {
         'Maintenance': 3,
-        'Early': 2,
+        'Stable': 3,
+        'Early Release': 2,
         'Experimental': 1,
     }
 
@@ -189,33 +219,44 @@ def select_versions(release_data: Dict, available_versions: List[str]) -> Dict[s
     for major_version_group in release_data.get('majorVersions', []):
         if major_version_group.get('state') == 'archived':
             continue
-        latest_releases = []
 
-        # Find all releases with latest=true
-        for release in major_version_group.get('releases', []):
-            if release.get('latest'):
-                release_name = release.get('name', '')
-                release_type = release.get('type', 'Experimental')
+        releases = major_version_group.get('releases', [])
 
-                parsed = parse_release_version(release_name)
-                if parsed:
-                    major, full_version = parsed
+        # Collect every release whose date parses and is on/before today.
+        shipped = []
+        for release in releases:
+            d = _parse_release_date(release.get('releaseDate'))
+            if d is not None and d <= today:
+                priority = type_priority.get(release.get('type', ''), 0)
+                shipped.append((d, priority, release))
 
-                    # Find matching directory
-                    matched_dir = match_release_to_directory(full_version, available_versions)
-                    if matched_dir:
-                        priority = type_priority.get(release_type, 0)
-                        latest_releases.append((major, matched_dir, priority, release_type))
-                        matched_majors.add(major)
+        candidate = None
+        if shipped:
+            # Most recent date wins; type priority breaks ties.
+            shipped.sort(key=lambda x: (x[0], x[1]), reverse=True)
+            candidate = shipped[0][2]
+        else:
+            # No dated/shipped entries — try the nightlies fallback.
+            ongoing = [r for r in releases if r.get('releaseDate') == 'Ongoing']
+            if ongoing:
+                ongoing.sort(
+                    key=lambda r: type_priority.get(r.get('type', ''), 0),
+                    reverse=True,
+                )
+                candidate = ongoing[0]
 
-        # Select the highest priority latest release for this major version
-        if latest_releases:
-            # Sort by priority (highest first)
-            latest_releases.sort(key=lambda x: x[2], reverse=True)
-            major, selected_dir, _, release_type = latest_releases[0]
+        if not candidate:
+            continue
 
-            # Use major version as key (with v prefix)
-            selected[f"v{major}"] = selected_dir
+        parsed = parse_release_version(candidate.get('name', ''))
+        if not parsed:
+            continue
+
+        major, full_version = parsed
+        matched_dir = match_release_to_directory(full_version, available_versions)
+        if matched_dir:
+            selected[f"v{major}"] = matched_dir
+            matched_majors.add(major)
 
     # Handle versions not in release data (fallback to semver)
     available_by_major = {}


### PR DESCRIPTION
Migrates `select_api_versions.py` from the `latest:true` field (being removed from `scale-releases.yaml` in the documentation PR) to date-based "latest shipped" selection. The new logic mirrors the Release Schedule bucketing in the documentation PR and handles both old and new yaml shapes gracefully.

## Changes

Release > Experimental as a date-tie breaker.
- Nightlies-only majors (every entry `releaseDate: "Ongoing"`) fall back to the highest-priority Ongoing entry so the lifecycle stays represented in the dropdown.
- Integer-lifecycle bridge: yaml `lifecycle: "26"` maps to directory major `"26.0"` for matching (mirrors the existing `archived_majors` bridge). Supports the TrueNAS 26+ semver naming (26.0.0, 26.0.1, 26.1.0).
- `extract_major_version` strips hyphenated pre-release suffixes (`v25.10-BETA.1` → `25.10`, `v26.0.0-BETA.1` → `26.0`) so pre-release directories don't leak as bogus `X.Y-BETA` majors.
- `match_release_to_directory` and the unmatched-major fallback now use a single TypeError-safe semver-aware comparator (`_sort_versions_desc`). Stable beats pre-release in the same numeric line.

## Merge order

**Merge first** in the DOCS-2556 chain. The documentation PR removes `latest:true` from `scale-releases.yaml`, which would break the old version of this script. The new script handles both schemas, so landing it first creates a safe transition window.
